### PR TITLE
Create Publish Artifact in GitHub Actions

### DIFF
--- a/.github/workflows/plasmic-push.yml
+++ b/.github/workflows/plasmic-push.yml
@@ -21,7 +21,7 @@ jobs:
         name: Set up node v14
         uses: actions/setup-node@v2
         with:
-          node-version: '14'
+          node-version: "14"
       - id: cache
         name: Recover cache
         uses: actions/cache@v2

--- a/.github/workflows/plasmic-push.yml
+++ b/.github/workflows/plasmic-push.yml
@@ -21,7 +21,7 @@ jobs:
         name: Set up node v14
         uses: actions/setup-node@v2
         with:
-          node-version: "14"
+          node-version: '14'
       - id: cache
         name: Recover cache
         uses: actions/cache@v2
@@ -42,3 +42,10 @@ jobs:
         with:
           branch: gh-pages
           folder: ${{ steps.build.outputs.publish_dir }}
+      - id: archive-publish-artifacts
+        name: Archive production artifacts
+        uses: actions/upload-artifact@v2
+        if: ${{ steps.build.outputs.publish_dir }}
+        with:
+          name: plasmic-publish-archive
+          path: ${{ steps.build.outputs.publish_dir }}

--- a/.github/workflows/plasmic.yml
+++ b/.github/workflows/plasmic.yml
@@ -72,6 +72,13 @@ jobs:
         with:
           branch: gh-pages
           folder: ${{ steps.build.outputs.publish_dir }}
+      - id: archive-publish-artifacts
+        name: Archive production artifacts
+        uses: actions/upload-artifact@v2
+        if: ${{ steps.build.outputs.publish_dir }}
+        with:
+          name: plasmic-publish-archive
+          path: ${{ steps.build.outputs.publish_dir }}
       - id: pr
         name: Creating pull request...
         uses: repo-sync/pull-request@v2


### PR DESCRIPTION
For use in downstream debugging of publish directory, it would be nice to have the ability to download the publish directory as an artifact from GitHub actions.  This would also provide support for LowCodeUnit deployments of either plasmic or push generated artifacts to other systems outside of GitHub pages, and may provide an additional workflow to web hooks that is still very secure. 